### PR TITLE
Fix Servers and the Brick Furnace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,77 +1,92 @@
 buildscript {
-    repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
-    }
+	repositories {
+		gradlePluginPortal()
+		mavenCentral()
+		maven { url = "https://maven.minecraftforge.net/" }
+	}
+	
+	dependencies {
+		classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "5.1.+"
+		classpath group: "gradle.plugin.com.matthewprenger", name: "CurseGradle", version: "1.4.0"
+        classpath group: "com.modrinth.minotaur", name: "com.modrinth.minotaur.gradle.plugin", version: "2.+"
+	}
 }
-apply plugin: 'net.minecraftforge.gradle.forge'
-//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
+apply plugin: "java"
+apply plugin: "net.minecraftforge.gradle"
+apply plugin: 'com.matthewprenger.cursegradle'
+apply plugin: 'com.modrinth.minotaur'
 
-version = "1.0"
-group = "com.beeshroom.brickery" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "brickery"
-
-sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
+	sourceCompatibility = "8"
+	targetCompatibility = "8"
 }
 
-minecraft {
-    version = "1.12.2-14.23.5.2768"
-    runDir = "run"
-    
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
-    // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "stable_39"
-    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+repositories {
+	maven {
+		url = "https://maven.minecraftforge.net/"
+	}
+	maven {
+        name = "CurseMaven"
+        url = "https://www.cursemaven.com"
+    }
 }
 
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
+	minecraft "net.minecraftforge:forge:1.12.2-14.23.5.2860"
+}
 
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
+minecraft {
+	mappings channel: "stable", version: "39-1.12"
+	
+	runs {
+		"client" {
+			workingDirectory file("./run")
+			mods { "${project.name}" { source sourceSets.main } }
+		}
+		
+		"server" {
+			workingDirectory file("./run/server")
+			mods { "${project.name}" { source sourceSets.main } }
+		}
+	}
 }
 
 processResources {
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+	inputs.property "version", project.version
+	
+	filesMatching("mcmod.info") {
+		expand "version": project.version
+	}
+}
 
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
+curseforge {
+    apiKey = System.getenv("CURSEFORGE_TOKEN") ?: project.findProperty("CURSEFORGE_TOKEN") as String ?: "DUMMY"
+    project {
+        id = curseforgeID
+        //changelogType = "markdown"
+        changelog = ""
+        releaseType = "release"
+        mainArtifact(tasks.getByName("jar"), {
+            relations {
                 
-        // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
-    }
-        
-    // copy everything else except the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
+            }
+        })
+        addGameVersion("Forge")
+        addGameVersion("1.12.2")
     }
 }
+
+modrinth {
+    token = System.getenv("MODRINTH_TOKEN") ?: project.findProperty("MODRINTH_TOKEN") as String ?: "DUMMY"
+    projectId = modrinthID
+    versionNumber = project.version
+    uploadFile = tasks.getByName("jar")
+    gameVersions = ["1.12.2"] 
+	loaders = ["forge"]
+}
+
+//When Forge 1.12 loads mods from a directory that's been put on the classpath, it expects to find resources in the same directory.
+//Default Gradle behavior puts resources in ./build/resources/main instead of ./build/classes/main/java. Let's change that.
+sourceSets.all { it.output.resourcesDir = it.output.classesDirs.getFiles().iterator().next() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
-# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx2G
+
+group=bee.beeshroom.Brickery
+name=Brickery
+
+curseforgeID=366121
+modrinthID=0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 14 12:28:28 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/src/main/java/com/beeshroom/brickery/blocks/BlockBase.java
+++ b/src/main/java/com/beeshroom/brickery/blocks/BlockBase.java
@@ -14,7 +14,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
-public class BlockBase extends Block implements IHasModel{ //added implements i has model
+public class BlockBase extends Block {
 
     public BlockBase(String name, Material material) {
         super(material);
@@ -24,21 +24,12 @@ public class BlockBase extends Block implements IHasModel{ //added implements i 
     }
 
     public Block register(String name) {
-    	   setTranslationKey(name);
+    	setTranslationKey(name);
         setRegistryName(Reference.MOD_ID, name);
         ForgeRegistries.BLOCKS.register(this);
         ForgeRegistries.ITEMS.register(new ItemBlock(this).setRegistryName(Reference.MOD_ID, name));
-        ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), 0, new ModelResourceLocation(new ResourceLocation(Reference.MOD_ID, name), "inventory"));
+        Main.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
         return this;
     }
-    
-    //just added this
-    @Override
-	public void registerModels()
-	{
-
-		Main.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
-	}
-
 
 }

--- a/src/main/java/com/beeshroom/brickery/blocks/BlockBrickFurnace.java
+++ b/src/main/java/com/beeshroom/brickery/blocks/BlockBrickFurnace.java
@@ -1,12 +1,15 @@
 package com.beeshroom.brickery.blocks;
 
 import java.util.Random;
+import java.util.logging.Logger;
 
 import com.beeshroom.brickery.Main;
 import com.beeshroom.brickery.init.ModBlocks;
 import com.beeshroom.brickery.init.ModItems;
 import com.beeshroom.brickery.tileentity.TileEntityBrickFurnace;
 import com.beeshroom.brickery.util.IHasModel;
+import com.beeshroom.brickery.util.Reference;
+import com.beeshroom.brickery.util.handlers.ConfigHandler;
 
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockHorizontal;
@@ -45,27 +48,26 @@ public class BlockBrickFurnace extends BlockContainer implements IHasModel
 		public static final PropertyDirection FACING = BlockHorizontal.FACING;
 		private final boolean isBurning;
 		private static boolean keepInventory;
-		private boolean states;
 		
 		public BlockBrickFurnace(String name, boolean isBurning, boolean state)
 		{
 			super(Material.ROCK);
 			this.setHardness(3.5F);
 			this.setDefaultState(this.blockState.getBaseState().withProperty(FACING, EnumFacing.NORTH));
-			states = state;
 			this.isBurning = isBurning;
 			
-			setCreativeTab(Main.CREATIVE_TAB);
+			if (!isBurning) setCreativeTab(Main.CREATIVE_TAB);
 			
 			float light = isBurning ? 0.75F : 0;
-			
 			setLightLevel(light);
 			
 			setTranslationKey(name);
 			setRegistryName(name);
 			
-			ModBlocks.BLOCKS.add(this);
-			ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+			if (ConfigHandler.BRICK_FURNACE) {
+				ModBlocks.BLOCKS.add(this);
+				ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+			}
 		}
 		
 		@Override
@@ -134,7 +136,7 @@ public class BlockBrickFurnace extends BlockContainer implements IHasModel
 	            double d0 = (double)pos.getX() + 0.5D;
 	            double d1 = (double)pos.getY() + rand.nextDouble() * 6.0D / 16.0D;
 	            double d2 = (double)pos.getZ() + 0.5D;
-	            double d3 = 0.52D;
+	            //double d3 = 0.52D;
 	            double d4 = rand.nextDouble() * 0.6D - 0.3D;
 
 	            if (rand.nextDouble() < 0.1D)
@@ -171,6 +173,7 @@ public class BlockBrickFurnace extends BlockContainer implements IHasModel
 
 	    	world.scheduleUpdate(new BlockPos(i, j, k), this, this.tickRate(world));
 	    }
+	    
 	    /**
 	     * Called when the block is right clicked by a player.
 	     */

--- a/src/main/java/com/beeshroom/brickery/blocks/BlockFancyPlanks.java
+++ b/src/main/java/com/beeshroom/brickery/blocks/BlockFancyPlanks.java
@@ -1,17 +1,17 @@
 package com.beeshroom.brickery.blocks;
 
-import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import java.util.List;
+
+import com.beeshroom.brickery.util.handlers.ConfigHandler;
 
 public class BlockFancyPlanks extends BlockBase {
 
@@ -40,7 +40,7 @@ public class BlockFancyPlanks extends BlockBase {
     @Override
     public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
-        tooltip.add(type);
+        if (ConfigHandler.TOOLTIPS) tooltip.add(type);
     }
 
 }

--- a/src/main/java/com/beeshroom/brickery/blocks/EnumFancyPlanks.java
+++ b/src/main/java/com/beeshroom/brickery/blocks/EnumFancyPlanks.java
@@ -5,12 +5,12 @@ import net.minecraft.util.IStringSerializable;
 
 public enum EnumFancyPlanks implements IStringSerializable {
 
-    OAK(0, "oak", "parquet"),
-    SPRUCE(1, "spruce", "basket-weave"),
-    BIRCH(2, "birch", "checkered"),
-    JUNGLE(3, "jungle", "diagonal"),
-    ACACIA(4, "acacia", "herringbone"),
-    DARK_OAK(5, "dark_oak", "laminate");
+    OAK(0, "oak", "Parquet"),
+    SPRUCE(1, "spruce", "Basket-weave"),
+    BIRCH(2, "birch", "Checkered"),
+    JUNGLE(3, "jungle", "Diagonal"),
+    ACACIA(4, "acacia", "Herringbone"),
+    DARK_OAK(5, "dark_oak", "Laminate");
 
     public String name, type;
     public int ID;

--- a/src/main/java/com/beeshroom/brickery/tileentity/TileEntityBrickFurnace.java
+++ b/src/main/java/com/beeshroom/brickery/tileentity/TileEntityBrickFurnace.java
@@ -1,7 +1,9 @@
 package com.beeshroom.brickery.tileentity;
 
+import java.util.logging.Logger;
 
 import com.beeshroom.brickery.blocks.BlockBrickFurnace;
+import com.beeshroom.brickery.util.Reference;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFurnace;
@@ -34,7 +36,6 @@ import net.minecraft.util.datafix.DataFixer;
 import net.minecraft.util.datafix.FixTypes;
 import net.minecraft.util.datafix.walkers.ItemStackDataLists;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -125,15 +126,13 @@ public class TileEntityBrickFurnace extends TileEntityLockable implements ITicka
 		      this.markDirty();
 		    }
 		  }
-
-		  //EDITED THIS TO SAY BRICK FURNACE.... I HOPE THIS WORKS... IF NOT, GOOD THING I WROTE THIS ANNOTATION
-		  //HERE SO I CAN EASILY FIND IT IF EVERYTHING BREAKS ahahahah
 		  
 		  @Override
 		  public String getName()
 		  {
-		    return this.hasCustomName() ? this.furnaceCustomName : "container.furnace";
+		    return this.hasCustomName() ? this.furnaceCustomName : "container.brickfurnace";
 		  }
+		  
 		  @Override
 		  public boolean hasCustomName()
 		  {
@@ -276,7 +275,7 @@ public class TileEntityBrickFurnace extends TileEntityLockable implements ITicka
 	            if (flag != this.isBurning())
 	            {
 	                flag1 = true;
-	                BlockFurnace.setState(this.isBurning(), this.world, this.pos);
+	                BlockBrickFurnace.setState(this.isBurning(), this.world, this.pos);
 	            }
 	        }
 
@@ -293,7 +292,7 @@ public class TileEntityBrickFurnace extends TileEntityLockable implements ITicka
 		  
 	    public int getCookTime(ItemStack stack)
 	    {
-	        return 260;
+	        return 160; // 1 coal = 10 items (with the longer fuel times [set in getItemBurnTime], 12)
 	    }
 
 	    
@@ -375,99 +374,7 @@ public class TileEntityBrickFurnace extends TileEntityLockable implements ITicka
 		   */
 		    public static int getItemBurnTime(ItemStack stack)
 		    {
-		        if (stack.isEmpty())
-		        {
-		            return 0;
-		        }
-		        else
-		        {
-		            int burnTime = net.minecraftforge.event.ForgeEventFactory.getItemBurnTime(stack);
-		            if (burnTime >= 0) return burnTime;
-		            Item item = stack.getItem();
-
-		            if (item == Item.getItemFromBlock(Blocks.WOODEN_SLAB))
-		            {
-		                return 150;
-		            }
-		            else if (item == Item.getItemFromBlock(Blocks.WOOL))
-		            {
-		                return 100;
-		            }
-		            else if (item == Item.getItemFromBlock(Blocks.CARPET))
-		            {
-		                return 67;
-		            }
-		            else if (item == Item.getItemFromBlock(Blocks.LADDER))
-		            {
-		                return 300;
-		            }
-		            else if (item == Item.getItemFromBlock(Blocks.WOODEN_BUTTON))
-		            {
-		                return 100;
-		            }
-		            else if (Block.getBlockFromItem(item).getDefaultState().getMaterial() == Material.WOOD)
-		            {
-		                return 300;
-		            }
-		            else if (item == Item.getItemFromBlock(Blocks.COAL_BLOCK))
-		            {
-		                return 16000;
-		            }
-		            else if (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).getToolMaterialName()))
-		            {
-		                return 200;
-		            }
-		            else if (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).getToolMaterialName()))
-		            {
-		                return 200;
-		            }
-		            else if (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).getMaterialName()))
-		            {
-		                return 200;
-		            }
-		            else if (item == Items.STICK)
-		            {
-		                return 100;
-		            }
-		            else if (item != Items.BOW && item != Items.FISHING_ROD)
-		            {
-		                if (item == Items.SIGN)
-		                {
-		                    return 200;
-		                }
-		                else if (item == Items.COAL)
-		                {
-		                    return 1600;
-		                }
-		                else if (item == Items.LAVA_BUCKET)
-		                {
-		                    return 20000;
-		                }
-		                else if (item != Item.getItemFromBlock(Blocks.SAPLING) && item != Items.BOWL)
-		                {
-		                    if (item == Items.BLAZE_ROD)
-		                    {
-		                        return 2400;
-		                    }
-		                    else if (item instanceof ItemDoor && item != Items.IRON_DOOR)
-		                    {
-		                        return 200;
-		                    }
-		                    else
-		                    {
-		                        return item instanceof ItemBoat ? 400 : 0;
-		                    }
-		                }
-		                else
-		                {
-		                    return 100;
-		                }
-		            }
-		            else
-		            {
-		                return 300;
-		            }
-		        }
+		    	return (int)(TileEntityFurnace.getItemBurnTime(stack) * 1.2);
 		    }
 
 		  public static boolean isItemFuel(ItemStack stack)

--- a/src/main/java/com/beeshroom/brickery/util/handlers/ConfigHandler.java
+++ b/src/main/java/com/beeshroom/brickery/util/handlers/ConfigHandler.java
@@ -1,0 +1,33 @@
+package com.beeshroom.brickery.util.handlers;
+
+import com.beeshroom.brickery.util.Reference;
+
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.Config.*;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Config(modid = Reference.MOD_ID)
+@EventBusSubscriber
+public class ConfigHandler {
+	@RequiresMcRestart
+	@Name("Brick Furnace")
+	@Comment("Enables the Brick Furnace, an upgrade to the Furnace"
+			+ "Disabling this will stop the block from being registered, removing it completely.")
+	public static boolean BRICK_FURNACE = true;
+	
+	@Name("Flooring Tooltips")
+	@Comment("The wood flooring blocks will contain tooltips explaining their pattern.")
+	public static boolean TOOLTIPS = false;
+	
+	@SubscribeEvent
+	public static void registerConfig(ConfigChangedEvent.OnConfigChangedEvent event)
+	{
+		if (event.getModID() == Reference.MOD_ID)
+		{
+			ConfigManager.sync(Reference.MOD_ID, Type.INSTANCE);
+		}
+	}
+}

--- a/src/main/resources/assets/brickery/lang/en_us.lang
+++ b/src/main/resources/assets/brickery/lang/en_us.lang
@@ -39,5 +39,5 @@ tile.fancy_acacia_planks.name=Acacia Flooring
 
 //brick furnace
 tile.brick_furnace.name=Brick Furnace
-container.brickfurnace.name=Brick Furnace
+container.brickfurnace=Brick Furnace
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "brickery",
   "name": "Brickery",
   "description": "Adds some new bricks",
-  "version": "1.0",
+  "version": "1.1",
   "mcversion": "[1.12.2]",
   "url": "",
   "updateUrl": "",


### PR DESCRIPTION
- Updates the build.gradle (adapted from modern-forge-1.12-template)
- Fixed the mod crashing on servers
- Fixed the Brick Furnace displaying the name "Furnace" in it's UI instead of "Brick Furnace"
- Fixed the Brick Furnace not conserving fuel and being slower than the regular furnace
- Fixed the Brick Furnace turning into a normal furnace when lit
- The lit version of the Brick Furnace is no longer displayed in creative mode's items menu
- Added options to disable the Brick Furnace and to hide flooring tooltips